### PR TITLE
changed error msg for address

### DIFF
--- a/src/contactsbot/decorators.py
+++ b/src/contactsbot/decorators.py
@@ -29,8 +29,11 @@ def require_more_eq_n_args(n):
     def decorator(func):
         @wraps(func)
         def inner(args, contacts):
-            if (len(args) < n):
-                raise ValueError(f'Operation Requires {n} or more args')
+            if (len(args) < 2):
+                raise ValueError(f'Operation Requires 2 args')
+            elif (len(args) < 4):
+                raise ValueError(f'Address must consist of at least 3 parts')
+            
             return func(args, contacts)
 
         return inner


### PR DESCRIPTION
Змінив текст помилки при роботі з адресою:
- Якщо не вводиться імʼя або вводиться тільки імʼя - має бути повідомлення "Operation Requires 2 args"
- Якщо вводиться імʼя і адреса, але адреса складається з одного або двох слів - "Address must consist of at least 3 parts"
Мінімальна кількість складових адреси зараз 3, а максимальна кількість складових частин адреси не обмежена, на випадок введення індексу або ще якихось додаткових даних. Обмеження є тільки на мінімальну (10) і максимальну (150) кількість символів в адресі.